### PR TITLE
Bugfix. Use `didRender` hook instead of `didInsertElement`

### DIFF
--- a/addon/components/format-json.js
+++ b/addon/components/format-json.js
@@ -2,14 +2,14 @@ import Component from '@ember/component'
 import layout from '../templates/components/format-json';
 import JSONFormatter from 'json-formatter-js'
 
-
 export default Component.extend({
-    layout,
-    open: 0,
-    didInsertElement(){
-        const formatter = new JSONFormatter(this.value, this.open);
-        let v = formatter.render();
-        this.element.append(v);
-    },
-    value: '',
+  layout,
+  open: 0,
+  value: '',
+
+  didRender() {
+    const formatter = new JSONFormatter(this.value, this.open);
+    this.element.innerHTML = '';
+    this.element.append(formatter.render());
+  },
 });

--- a/tests/integration/components/format-json-test.js
+++ b/tests/integration/components/format-json-test.js
@@ -1,20 +1,44 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | format-json', function(hooks) {
   setupRenderingTest(hooks);
 
   test('render json', async function(assert) {
-      assert.expect(2);
+    await render(hbs`{{format-json}}`);
+    assert.equal(this.element.innerText.trim(), '""');
 
-      await render(hbs`{{format-json}}`);
-      assert.equal(this.element.innerText.trim(), '""');
-
-      this.set('value', {'a': 1})
-      await render(hbs`<FormatJson @value={{this.value}}/>`);
-      assert.equal(this.element.querySelector("div.json-formatter-row").getAttribute("class"), 'json-formatter-row', 'render to json');
+    this.set('value', { a: 1 });
+    await render(hbs`<FormatJson @value={{value}}/>`);
+    assert.equal(
+      this.element.querySelector('div.json-formatter-row').getAttribute("class"),
+      'json-formatter-row',
+      'render to json'
+    );
   });
 
+  test('rerender on update the value', async function(assert) {
+    this.set('value', { a: "initial value" });
+    await render(hbs`<FormatJson @value={{value}}/>`);
+    await click('.json-formatter-toggler-link');
+    await waitFor('.json-formatter-string');
+
+    assert.equal(
+      this.element.querySelector('.json-formatter-string').innerText.trim(),
+      '"initial value"',
+      'it renders initial value'
+    );
+
+    this.set('value', { b: 'updated value' });
+    await click('.json-formatter-toggler-link');
+    await waitFor('.json-formatter-string');
+
+    assert.equal(
+      this.element.querySelector('.json-formatter-string').innerText.trim(),
+      '"updated value"',
+      'it renders new value'
+    );
+  });
 });


### PR DESCRIPTION
There is a bug with using `didInsertElement` hook. If the value has been updated then `FormatJson` will not rerender JSON viewer. I've fixed the bug and added a test case